### PR TITLE
bump passageidentity gem version

### DIFF
--- a/01-Login/Gemfile
+++ b/01-Login/Gemfile
@@ -6,7 +6,7 @@ ruby "3.1.1"
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.0.2", ">= 7.0.2.3"
 
-gem "passageidentity", ">= 0.0.2"
+gem "passageidentity", ">= 0.0.3"
 
 # env vars for dev environment
 gem 'dotenv-rails', groups: [:development, :test]

--- a/01-Login/Gemfile.lock
+++ b/01-Login/Gemfile.lock
@@ -160,7 +160,7 @@ GEM
     nokogiri (1.13.4-x86_64-darwin)
       racc (~> 1.4)
     openssl (3.0.0)
-    passageidentity (0.0.2)
+    passageidentity (0.0.3)
       faraday (>= 0.17.0, < 2.0)
       jwt (>= 2.3.0)
       openssl (>= 3.0.0)


### PR DESCRIPTION
This should only be merged after https://github.com/passageidentity/passage-ruby/pull/3 is merged and the gem has been published